### PR TITLE
Added idle_timelimit to nslcd

### DIFF
--- a/templates/nslcd.conf.erb
+++ b/templates/nslcd.conf.erb
@@ -40,3 +40,8 @@ filter <%= f %>
 # The search scope.
 #scope sub
 
+# Set idle timeout on LDAP session (default 3600)
+#idle_timelimit 3600
+
+# nslcd until 0.7.8 (CentOS 6) has issues with long time connection
+idle_timelimit 180


### PR DESCRIPTION
There is some bug in nslcd in CentOS6 which causes broking TCP LDAP connections few hours after restarting nslcd.

One workaround is to set idle_timelimit to lower value than default 3600 seconds. 

( the bug is mentioned here https://access.redhat.com/solutions/62655 without solution,
  leak of solution on https://access.redhat.com/solutions/458013,
  Debian version of bug https://bugs.launchpad.net/ubuntu/+source/nss-pam-ldapd/+bug/1074213 )

I've found other confirmations of the bug, but I'm not able to find them now.

Patch has been tested on Vagrant boxen for several hours without problems.
